### PR TITLE
Next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hooks",
-  "version": "1.2.0",
+  "version": "1.2.0-beta.0",
   "description": "A collection of commonly-used custom React Hooks.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hooks",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "description": "A collection of commonly-used custom React Hooks.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/use-mount-transition.ts
+++ b/src/use-mount-transition.ts
@@ -7,7 +7,9 @@ const RENDER_TIMEOUT = 35;
 interface UseTransitionOptions {
   shouldBeMounted: boolean;
   transitionDurationMs?: number;
+  onEntering?: () => void;
   onEnter?: () => void;
+  onLeaving?: () => void;
   onLeave?: () => void;
   onEnteringTimeout?: number;
 }
@@ -15,7 +17,9 @@ interface UseTransitionOptions {
 export default function useMountTransition({
   shouldBeMounted,
   transitionDurationMs,
+  onEntering,
   onEnter,
+  onLeaving,
   onLeave,
 
   onEnteringTimeout = RENDER_TIMEOUT,
@@ -28,7 +32,9 @@ export default function useMountTransition({
   }
 
   const optionsRef = useCurrentRef({
+    onEntering,
     onEnter,
+    onLeaving,
     onLeave,
   });
 
@@ -106,6 +112,10 @@ export default function useMountTransition({
           closeDuration = elapsedTime;
         }
 
+        if (typeof optionsRef.current.onLeaving === 'function') {
+          optionsRef.current.onLeaving();
+        }
+
         updateTransitionState(
           mergeNewState({
             useActiveClass: false,
@@ -134,6 +144,10 @@ export default function useMountTransition({
           );
 
           onEnterTimeoutRef.current = window.setTimeout(() => {
+            if (typeof optionsRef.current.onEntering === 'function') {
+              optionsRef.current.onEntering();
+            }
+
             updateTransitionState(
               mergeNewState({
                 useActiveClass: true,
@@ -143,6 +157,10 @@ export default function useMountTransition({
             startTimeMs.current = new Date().getTime();
           }, enterTimeoutToUse);
         } else {
+          if (typeof optionsRef.current.onEntering === 'function') {
+            optionsRef.current.onEntering();
+          }
+
           updateTransitionState(
             mergeNewState({
               shouldRender: true,


### PR DESCRIPTION
Supersedes #23 

The original text from that issue:

---

Todo:

- [ ] Change return API
  - include `state`: `ENTERING`, `ENTERED`, `LEAVING`, `IDLE`.
- [ ] Cut 2.0 release

The above can be useful for, say, disabling buttons in modals